### PR TITLE
Minor fixes for using smartsurvey data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ include
 lib
 pip-selfcheck.json
 .Python
+share

--- a/README.md
+++ b/README.md
@@ -10,13 +10,15 @@ The project is described in the [blog post](https://gdsdata.blog.gov.uk/2016/12/
 
 Nominally this application requires the following:
 
-* Python 3.5
+* Python 3.6.1
 * gnu make (required for using makefile)
 
 I would recommend setting up an environment using anaconda or venv before proceeding. `pip install -r requirements.txt` can then be used to install the required packages.
 The only out of the ordinary requirement is the [classifyintents](https://github.com/ukgovdatascience/classifyintents) package, developed to handle the cleaning of the data; this is installed with the above step.
 
 ## Instructions
+
+** When working with smartsurvey data the data must first be reformatted by running `Rscript reformat.R input.csv output.csv`. **
 
 To execute, run `make` from the root directory.
 

--- a/predictor.py
+++ b/predictor.py
@@ -64,7 +64,8 @@ def main():
     # Run the prediction
 
     predicted_classes = exported_pipeline.predict(intent.cleaned)
-
+    
+    print('Predicted classes:')
     print(np.bincount(predicted_classes))
 
     pd.Series(predicted_classes).to_csv('predicted_classes.csv')
@@ -83,29 +84,31 @@ def main():
     # Label the raw dataset with 'ok' and 'nones'
 
     intent.raw['code'] = ''
-    intent.raw.loc[intent.raw['RespondentID'].isin(predicted_classes),'code'] = 'ok'
-    intent.raw.loc[intent.raw['RespondentID'].isin(easy_nones),'code'] = 'none'
+    intent.raw.loc[intent.raw['respondent_ID'].isin(predicted_classes),'code'] = 'ok'
+    intent.raw.loc[intent.raw['respondent_ID'].isin(easy_nones),'code'] = 'none'
     
     # Standardise the column type for respondent ID, for merging
     
-    intent.raw['RespondentID'] = intent.raw['RespondentID'].astype('int')
+    intent.raw['respondent_ID'] = intent.raw['respondent_ID'].astype('int')
     intent.data['respondent_ID'] = intent.data['respondent_ID'].astype('int')   
     
-    # Concatenate easy_nones with intent.data to ensureNow merge the api lookup data into intent.raw
+    # Concatenate easy_nones with intent.data to ensure
+    # Now merge the api lookup data into intent.raw
         
     urls = intent.data_full.loc[:,['respondent_ID','start_date','end_date','full_url','page','section','org']]
 
     output = intent.raw.merge(
             right=urls,
             how='left',
-            left_on='RespondentID',
+            left_on='respondent_ID',
             right_on='respondent_ID'
             )
     
         
     # Remove the rather unhelpful US system dates, retaining only the clean ones.
-
-    output.drop(['RespondentID','StartDate','EndDate','Custom Data'],axis=1,inplace=True)
+    
+    # No longer need to drop US dates as these do not exist!
+    #output.drop(['respondent_ID','start_date','end_date','full_url'],axis=1,inplace=True)
 
     # Save the file out
     

--- a/reformat.R
+++ b/reformat.R
@@ -1,0 +1,141 @@
+#!/usr/bin/env Rscript
+
+library(dplyr)
+library(readr)
+library(lubridate)
+
+args = commandArgs(trailingOnly=TRUE)
+
+if (length(args)!=2) {
+  stop("Two arguments must be provided: an input and an output dataset", call.=FALSE)
+}
+
+raw <- read.csv(
+  args[1], 
+  stringsAsFactors = FALSE
+)
+
+colnames(raw) = make.names(colnames(raw))
+
+mapping <- c(
+  "UserID" = "respondent_ID",
+  "UserNo" = "user_no_drop",
+  "Tracking.Link" = "collector_id",
+  "Started" = "start_date",
+  "Ended" = "end_date",
+  "IP.Address" = "ip_address",
+  "Email" = "email_address",
+  "Name" = "first_name",
+  "Unique.ID" = "unique_id_drop",
+  #last_name
+  "Page.Path" = "full_url",
+  "Q1..Are.you.using.GOV.UK.for.professional.or.personal.reasons."="cat_work_or_personal",
+  "Q2..What.kind.of.work.do.you.do."="comment_what_work",
+  "Q3..Describe.why.you.came.to.GOV.UK.todayPlease.do.not.include.personal.or.financial.information..eg.your.National.Insurance.number.or.credit.card.details."="comment_why_you_came",
+  "Q4..Have.you.found.what.you.were.looking.for." ="cat_found_looking_for",
+  "Q5..Overall..how.did.you.feel.about.your.visit.to.GOV.UK.today." = "cat_satisfaction",
+  "Q6..Have.you.been.anywhere.else.for.help.with.this.already."="cat_anywhere_else_help",
+  "Q7..Where.did.you.go.for.help."="comment_where_for_help",
+  "Q8..If.you.wish.to.comment.further..please.do.so.here.Please.do.not.include.personal.or.financial.information..eg.your.National.Insurance.number.or.credit.card.details."="comment_further_comments"#,
+  #"Unnamed= 13"="comment_other_found_what",
+  #"Unnamed= 17"="comment_other_else_help",
+  #"dummy"="comment_other_where_for_help"
+)
+
+# Quick check of the column name conversions
+
+# View(cbind(
+# colnames(a),
+# mapping[colnames(a)]
+# ))
+
+# Convert to data_frame
+
+colnames(raw) <- mapping[colnames(raw)]
+raw_clean_names <- as_data_frame(raw)
+
+# Fix some disparities with the data:
+
+
+fix_NA <- function(x) {
+ 
+  x[x == ""|x=="-"] <- NA
+  
+  return(x)
+   
+}
+
+fix_cat <- function(x) {
+ 
+  x[!x %in% c("No","Yes","Not sure / Not yet")] <- NA
+  
+  return(x)
+   
+}
+
+fill_other <- function(x) {
+
+  x[x %in% c("No","Yes","Not sure / Not yet","-")] <- NA
+  
+  
+  return(x)
+  
+}
+
+fix_missing_urls <- function(x) {
+
+  # Temporary fix to deal with missing data in the April survey
+  x[x==""] <- NA
+  return(x)
+}
+
+clean <- raw_clean_names %>% 
+  transmute(
+  # Add NA columns
+  respondent_ID,
+  collector_id,
+  start_date = dmy_hms(start_date),
+  end_date = dmy_hms(end_date),
+  ip_address,
+  email_address,
+  first_name,
+  last_name = NA, 
+  full_url = fix_missing_urls(full_url),
+  cat_work_or_personal = fix_NA(cat_work_or_personal),
+  comment_what_work = fix_NA(comment_what_work),
+  comment_why_you_came = fix_NA(comment_why_you_came),
+  comment_other_found_what = fill_other(cat_found_looking_for),
+  # must get comments before cleaning cat of NAs
+  cat_found_looking_for = fix_cat(cat_found_looking_for),
+  cat_satisfaction = fix_NA(cat_satisfaction),
+  comment_other_where_for_help = fill_other(cat_anywhere_else_help),
+  cat_anywhere_else_help = fix_cat(cat_anywhere_else_help),
+  comment_other_else_help = NA,
+  comment_where_for_help = fix_NA(comment_where_for_help),
+  comment_further_comments = fix_NA(comment_further_comments)
+)
+# cat_anywhere_else_help
+
+# Organise columns:
+
+clean_organised <- clean %>%
+  select(
+  respondent_ID, collector_id, start_date, end_date,
+  full_url, cat_work_or_personal, comment_what_work, 
+  comment_why_you_came, cat_found_looking_for, comment_other_found_what, 
+  cat_satisfaction, comment_other_where_for_help, cat_anywhere_else_help, 
+  comment_other_else_help, comment_where_for_help, comment_further_comments 
+  )
+
+
+clean_organised %>% 
+  write_csv(
+    args[2], 
+    na = ''
+    )
+
+# Exmpty fields!
+# comment_other_else_help
+# comment_ther_found_what
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 appdirs==1.4.3
-classifyintents==0.5.1
+git+git://github.com/ukgovdatascience/classifyintents.git@7a3bda943681e3eb272f2cd42b7c19a79a06742d
 deap==1.0.1
 numpy==1.11.2
 packaging==16.8


### PR DESCRIPTION
* Update README.md
* Add reformat.R as a temporary fix for reformatting data in the new format.
* predictor.py previously expected to load files with a messy column name format. Since all the cleaning now goes on in reformat.R, this we don't need to worry about messy formats in predictor.py anymore.
* Change the version of classifyintent that is used. This version will be merged to master, but needs to have its failing tests fixed first.

All these measures are stop gaps. In future this pipeline will not make any use of flat files, and will instead depend on a postgres backend. Note that ip address, email address, and names are not collected, but the blank fields remain in the existing bulk downloads.